### PR TITLE
Unpin postcss version; use ^ range

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/SuperOl3g/postcss-image-set-polyfill.git"
   },
   "dependencies": {
-    "postcss": "6.0.1",
+    "postcss": "^6.0.1",
     "postcss-media-query-parser": "0.2.3",
     "postcss-value-parser": "3.3.0"
   },


### PR DESCRIPTION
Without this, postcss is being downloaded twice into most projects that use this; which is poor for disk space and performance.