### PR TITLE
Several improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,31 +6,35 @@
 [PostCSS]: https://github.com/postcss/postcss
 
 ```css
-/* Input example */
 .foo {
-    background-image: image-set(url(img/test.png) 1x,
-                                url(img/test-2x.png) 2x,
-                                url(my-img-print.png) 600dpi);
+  align-items: center;
+  background-image: image-set(url(img/test.png) 1x,
+                              url(img/test-2x.png) 2x,
+                              url(my-img-print.png) 600dpi);
+  color: black;
 }
-```
 
-```css
-/* Output example */
+/* becomes */
+
 .foo {
-    background-image: url(img/test.png);
+  align-items: center;
+  background-image: url(img/test.png);
 }
 
 @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
-    .foo {
-        background-image: url(img/test-2x.png);
-    }
+  .foo {
+    background-image: url(img/test-2x.png);
+  }
 }
 
-
 @media (-webkit-min-device-pixel-ratio: 6.25), (min-resolution: 600dpi) {
-    .foo {
-        background-image: url(my-img-print.png);
-    }
+  .foo {
+    background-image: url(my-img-print.png);
+  }
+}
+
+.foo {
+  color: black;
 }
 ```
 <a href="https://astexplorer.net/#/gist/86d1248cc4628f850454d3191c95efec/3bbf606fe0ef2662917a845aa16a715d06435650" target="_blank">→Try it online←</a>
@@ -52,6 +56,45 @@ postcss([postcssImageSet]).process(YOUR_CSS, /* options */);
 
 See [PostCSS] docs for examples for your environment.
 
+## Option
+
+### preserve
+
+The `preserve` option determines whether the original `image-set()` rule should
+or not should not be removed. By default, the original `image-set()` rule is
+removed.
+
+```js
+postcssImageSet({ preserve: true })
+```
+
+```css
+.foo {
+  align-items: center;
+  background-image: image-set(url(img/test.png) 1x,
+                              url(img/test-2x.png) 2x);
+  color: black;
+}
+
+/* becomes */
+
+.foo {
+  align-items: center;
+  background-image: url(img/test.png);
+}
+
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+  .foo {
+    background-image: url(img/test-2x.png);
+  }
+}
+
+.foo {
+  background-image: image-set(url(img/test.png) 1x,
+                              url(img/test-2x.png) 2x);
+  color: black;
+}
+```
 
 ### ⚠️️ Warning
 

--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ const parseValue = (value, decl) => {
 
 module.exports = postcss.plugin('postcss-image-set-polyfill', () =>
     css => {
-        css.walkDecls(/^(background-image|background)$/, decl => {
+        css.walkDecls(decl => {
             // ignore nodes we already visited
             if (decl.__visited) {
                 return;

--- a/index.js
+++ b/index.js
@@ -65,8 +65,10 @@ const parseValue = (value, decl) => {
     };
 };
 
-module.exports = postcss.plugin('postcss-image-set-polyfill', () =>
-    css => {
+module.exports = postcss.plugin('postcss-image-set-polyfill', opts => {
+    const preserve = Boolean(Object(opts).preserve);
+
+    return css => {
         css.walkDecls(decl => {
             // make sure we have image-set
             if (!IMAGE_SET_FUNC_REGEX.test(decl.value)) {
@@ -153,13 +155,15 @@ module.exports = postcss.plugin('postcss-image-set-polyfill', () =>
             // insert the cloned parent and fallback atrules before the parent
             parent.before([parentClone].concat(atrules));
 
-            // remove the original declaration
-            decl.remove();
+            // conditionally remove the original declaration
+            if (!preserve) {
+                decl.remove();
 
-            // cleanup leftover emptied parent
-            if (!parent.nodes.length) {
-                parent.remove();
+                // cleanup leftover emptied parent
+                if (!parent.nodes.length) {
+                    parent.remove();
+                }
             }
         });
-    }
-);
+    };
+});

--- a/index.js
+++ b/index.js
@@ -11,6 +11,8 @@ const DPI_RATIO = {
     dpi: 1
 };
 
+const IMAGE_SET_FUNC_REGEX = /(^|[^\w-])(-webkit-)?image-set\([\W\w]*\)/
+
 // convert all sizes to dpi for sorting
 const convertSize = (size, decl) => {
     if (!size) {
@@ -73,7 +75,7 @@ module.exports = postcss.plugin('postcss-image-set-polyfill', () =>
             }
 
             // make sure we have image-set
-            if (!decl.value || decl.value.indexOf('image-set') === -1) {
+            if (!IMAGE_SET_FUNC_REGEX.test(decl.value)) {
                 return;
             }
 
@@ -83,7 +85,7 @@ module.exports = postcss.plugin('postcss-image-set-polyfill', () =>
             const parsedValues = commaSeparatedValues.map(value => {
                 const result = {};
 
-                if (value.indexOf('image-set') === -1) {
+                if (!IMAGE_SET_FUNC_REGEX.test(value)) {
                     result.default = value;
                     return result;
                 }

--- a/index.js
+++ b/index.js
@@ -40,15 +40,15 @@ const parseValue = (value, decl) => {
     const imageSetChunks = valueChunks.shift().nodes;
 
     const sizes = imageSetChunks
-            .filter(chunk => chunk.type === 'word')
-            .map(chunk => convertSize(stringify(chunk), decl));
+        .filter(chunk => chunk.type === 'word')
+        .map(chunk => convertSize(stringify(chunk), decl));
 
     const urls = imageSetChunks
-            .filter(chunk => chunk.type === 'function' || chunk.type === 'string')
-            .map(chunk => {
-                const str = stringify(chunk);
-                return chunk.type === 'string' ? `url(${str})` : str;
-            });
+        .filter(chunk => chunk.type === 'function' || chunk.type === 'string')
+        .map(chunk => {
+            const str = stringify(chunk);
+            return chunk.type === 'string' ? `url(${str})` : str;
+        });
 
     const suffix = valueChunks.length ?
         valueChunks

--- a/index.js
+++ b/index.js
@@ -118,9 +118,14 @@ module.exports = postcss.plugin('postcss-image-set-polyfill', () =>
             decl.value = parsedValues.map(val => val.default).join(',');
 
             const parent = decl.parent;
+            const afterNodes = parent.nodes.slice(parent.nodes.indexOf(decl) + 1)
+            const atruleKeys = Object.keys(mediaQueryList).sort()
 
-            const atrules = Object.keys(mediaQueryList)
-                .sort()
+            if (!atruleKeys.length) {
+                return
+            }
+
+            const atrules = atruleKeys
                 .map(size => {
                     const minResQuery = `(min-resolution: ${size}dpi)`;
                     const minDPRQuery = `(-webkit-min-device-pixel-ratio: ${mediaQueryList[size]})`;
@@ -148,7 +153,15 @@ module.exports = postcss.plugin('postcss-image-set-polyfill', () =>
                     return atrule;
                 });
 
-                parent.after(atrules);
+            if (afterNodes.length) {
+                const parentClone = parent.clone().removeAll();
+
+                parentClone.append(afterNodes);
+
+                atrules.push(parentClone);
+            }
+
+            parent.after(atrules);
         });
     }
 );

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "dependencies": {
     "postcss": "^6.0.20",
-    "postcss-media-query-parser": "^0.2.3",
     "postcss-value-parser": "^3.3.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -20,16 +20,16 @@
     "url": "https://github.com/SuperOl3g/postcss-image-set-polyfill.git"
   },
   "dependencies": {
-    "postcss": "6.0.1",
-    "postcss-media-query-parser": "0.2.3",
-    "postcss-value-parser": "3.3.0"
+    "postcss": "^6.0.20",
+    "postcss-media-query-parser": "^0.2.3",
+    "postcss-value-parser": "^3.3.0"
   },
   "devDependencies": {
-    "benchmark": "2.1.4",
-    "chai": "2.2.0",
-    "eslint": "3.15.0",
-    "husky": "0.13.4",
-    "mocha": "3.2.0"
+    "benchmark": "^2.1.4",
+    "chai": "^4.1.2",
+    "eslint": "^4.19.0",
+    "husky": "^0.14.3",
+    "mocha": "^5.0.4"
   },
   "scripts": {
     "test": "mocha",

--- a/test/test.js
+++ b/test/test.js
@@ -31,6 +31,33 @@ describe('postcss-image-set-polyfill', () => {
         test(input, input, done);
     });
 
+    it('parses a simple image-set', done => {
+        const input =
+            `a {
+                order: 1;
+                background-image: image-set(
+                    url(img/test.png) 1x,
+                    url(img/test-2x.png) 2x
+                );
+                order: 2;
+            }`;
+        const output =
+            `a {
+                order: 1;
+                background-image: url(img/test.png);
+            }
+            @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+                a {
+                    background-image: url(img/test-2x.png);
+                }
+            }
+            a {
+                order: 2;
+            }`;
+
+        test(input, output, done);
+    });
+
     it('parses the image-set', done => {
         const input =
             `a{
@@ -246,17 +273,15 @@ describe('postcss-image-set-polyfill', () => {
                 a {
                     background-image: url(img/test.png);
                 }
-            }
-            @media (min-width: 1000px) and (-webkit-min-device-pixel-ratio: 2), 
-                (min-width: 1000px) and (min-resolution: 192dpi) {
-                a {
-                    background-image: url(img/test-2x.png);
+                @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+                    a {
+                        background-image:url(img/test-2x.png);
+                    }
                 }
-            }
-            @media (min-width: 1000px) and (-webkit-min-device-pixel-ratio: 6.25),
-                (min-width: 1000px) and (min-resolution: 600dpi) {
-                a {
-                    background-image: url(my-img-print.png);
+                @media (-webkit-min-device-pixel-ratio: 6.25), (min-resolution: 600dpi) {
+                    a {
+                        background-image: url(my-img-print.png);
+                    }
                 }
             }`;
 
@@ -280,17 +305,17 @@ describe('postcss-image-set-polyfill', () => {
                 a {
                     background-image: url(img/test.png);
                 }
-            }
-            @media (min-width: 768px) and (max-width: 1024px) and (-webkit-min-device-pixel-ratio: 2),
-                (min-width: 768px) and (max-width: 1024px) and (min-resolution: 192dpi) {
-                a {
-                    background-image: url(img/test-2x.png);
+                @media (-webkit-min-device-pixel-ratio: 2),
+                    (min-resolution: 192dpi) {
+                    a {
+                        background-image: url(img/test-2x.png);
+                    }
                 }
-            }
-            @media (min-width: 768px) and (max-width: 1024px) and (-webkit-min-device-pixel-ratio: 6.25),
-                (min-width: 768px) and (max-width: 1024px) and (min-resolution: 600dpi) {
-                a {
-                    background-image: url(my-img-print.png);
+                @media (-webkit-min-device-pixel-ratio: 6.25),
+                    (min-resolution: 600dpi) {
+                    a {
+                        background-image: url(my-img-print.png);
+                    }
                 }
             }`;
 
@@ -314,21 +339,17 @@ describe('postcss-image-set-polyfill', () => {
                 a {
                     background-image: url(img/test.png);
                 }
-            }
-            @media (min-width: 768px) and (-webkit-min-device-pixel-ratio: 2),
-                (min-width: 768px) and (min-resolution: 192dpi),
-                (max-width: 1024px) and (-webkit-min-device-pixel-ratio: 2),
-                (max-width: 1024px) and (min-resolution: 192dpi) {
-                a {
-                    background-image: url(img/test-2x.png);
+                @media (-webkit-min-device-pixel-ratio: 2),
+                    (min-resolution: 192dpi) {
+                    a {
+                        background-image: url(img/test-2x.png);
+                    }
                 }
-            }
-            @media (min-width: 768px) and (-webkit-min-device-pixel-ratio: 6.25),
-                (min-width: 768px) and (min-resolution: 600dpi),
-                (max-width: 1024px) and (-webkit-min-device-pixel-ratio: 6.25),
-                (max-width: 1024px) and (min-resolution: 600dpi) {
-                a {
-                    background-image: url(my-img-print.png);
+                @media (-webkit-min-device-pixel-ratio: 6.25),
+                    (min-resolution: 600dpi) {
+                    a {
+                        background-image: url(my-img-print.png);
+                    }
                 }
             }`;
 

--- a/test/test.js
+++ b/test/test.js
@@ -5,8 +5,8 @@ const expect  = require('chai').expect;
 const postcss = require('postcss');
 const imageSet = require('../');
 
-const test = function(input, output, done) {
-    expect(postcss(imageSet).process(input).css.replace(/[ \n]/g, ''))
+const test = function(input, output, done, opts) {
+    expect(postcss(imageSet(opts)).process(input).css.replace(/[ \n]/g, ''))
         .to.eql(output.replace(/[ \n]/g, ''));
 
     done();
@@ -56,6 +56,37 @@ describe('postcss-image-set-polyfill', () => {
             }`;
 
         test(input, output, done);
+    });
+
+    it('parses a simple image-set with preserve option', done => {
+        const input =
+            `a {
+                order: 1;
+                background-image: image-set(
+                    url(img/test.png) 1x,
+                    url(img/test-2x.png) 2x
+                );
+                order: 2;
+            }`;
+        const output =
+            `a {
+                order: 1;
+                background-image: url(img/test.png);
+            }
+            @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+                a {
+                    background-image: url(img/test-2x.png);
+                }
+            }
+            a {
+                background-image: image-set(
+                    url(img/test.png) 1x,
+                    url(img/test-2x.png) 2x
+                );
+                order: 2;
+            }`;
+
+        test(input, output, done, { preserve: true });
     });
 
     it('parses the image-set', done => {


### PR DESCRIPTION
- Fixes declaration ordering for nodes before and after the one containing `image-set()`
- Adds the ability to use `image-set` in any declaration (like `content`, or the who-knows future).
- Adds a `preserve` option to preserve the original `image-set()` declaration
- Removes the `postcss-media-query-parser` dependency
- Improves the `image-set()` detection done before value parsing takes place
- Improves how fallbacks are inserted so that PostCSS does not revisit nodes
- Updates dependencies to be unpinned to work with any major-compatible version of itself
- Updates all dependencies to their latest version

Each commit should reflect the individual change described by its label.